### PR TITLE
Fix commission voucher referencing correct doctype

### DIFF
--- a/sales_agent_commission/doctype/commission_payment_item/commission_payment_item.json
+++ b/sales_agent_commission/doctype/commission_payment_item/commission_payment_item.json
@@ -29,7 +29,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Commission Entry",
-   "options": "Agent Commission Entry",
+  "options": "Sales Agent Commission Entry",
    "reqd": 1
   },
   {

--- a/sales_agent_commission/doctype/commission_payment_voucher/commission_payment_voucher.json
+++ b/sales_agent_commission/doctype/commission_payment_voucher/commission_payment_voucher.json
@@ -133,7 +133,7 @@
  "is_submittable": 1,
  "links": [
   {
-   "link_doctype": "Agent Commission Entry",
+   "link_doctype": "Sales Agent Commission Entry",
    "link_fieldname": "commission_payment_voucher"
   }
  ],

--- a/sales_agent_commission/doctype/commission_payment_voucher/commission_payment_voucher.py
+++ b/sales_agent_commission/doctype/commission_payment_voucher/commission_payment_voucher.py
@@ -53,7 +53,7 @@ class CommissionPaymentVoucher(Document):
 				frappe.throw(_("Commission Entry is required for all entries"))
 			
 			# Validate paid amount
-			commission_doc = frappe.get_doc("Agent Commission Entry", entry.commission_entry)
+			commission_doc = frappe.get_doc("Sales Agent Commission Entry", entry.commission_entry)
 			if flt(entry.paid_amount) > flt(commission_doc.outstanding_amount):
 				frappe.throw(_("Paid amount cannot exceed outstanding amount for commission entry {0}").format(entry.commission_entry))
 
@@ -68,7 +68,7 @@ class CommissionPaymentVoucher(Document):
 	def update_commission_entries(self):
 		"""Update commission entries with payment information"""
 		for entry in self.commission_entries:
-			commission_doc = frappe.get_doc("Agent Commission Entry", entry.commission_entry)
+			commission_doc = frappe.get_doc("Sales Agent Commission Entry", entry.commission_entry)
 			
 			# Update paid amount
 			commission_doc.paid_amount = flt(commission_doc.paid_amount or 0) + flt(entry.paid_amount)
@@ -87,7 +87,7 @@ class CommissionPaymentVoucher(Document):
 	def revert_commission_entries(self):
 		"""Revert commission entries when voucher is cancelled"""
 		for entry in self.commission_entries:
-			commission_doc = frappe.get_doc("Agent Commission Entry", entry.commission_entry)
+			commission_doc = frappe.get_doc("Sales Agent Commission Entry", entry.commission_entry)
 			
 			# Revert paid amount
 			commission_doc.paid_amount = flt(commission_doc.paid_amount or 0) - flt(entry.paid_amount)
@@ -109,14 +109,14 @@ class CommissionPaymentVoucher(Document):
 @frappe.whitelist()
 def get_pending_commission_entries(agent, company):
 	"""Get pending commission entries for an agent"""
-	return frappe.get_all("Agent Commission Entry",
+	return frappe.get_all("Sales Agent Commission Entry",
 		filters={
-			"agent": agent,
-			"company": company,
-			"payment_status": ["in", ["Pending", "Partially Paid"]],
-			"docstatus": 1
+		"agent": agent,
+		"company": company,
+		"payment_status": ["in", ["Pending", "Partially Paid"]],
+		"docstatus": 1
 		},
-		fields=["name", "sales_invoice", "customer", "posting_date", "total_commission_amount", "paid_amount", "outstanding_amount"]
+	fields=["name", "sales_invoice", "customer", "posting_date", "total_commission_amount", "paid_amount", "outstanding_amount"]
 	)
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- fix Commission Payment Voucher to use Sales Agent Commission Entry
- update related JSON documents

## Testing
- `python3 -m py_compile sales_agent_commission/doctype/commission_payment_voucher/commission_payment_voucher.py`
- `find sales_agent_commission -name '*.py' | xargs python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_68734fc4b9188331b0d1473e2894997e